### PR TITLE
Adding unit tests and integration tests

### DIFF
--- a/src/Agents/Commodity_Correlation_Agents/commodity_correlation_agent.py
+++ b/src/Agents/Commodity_Correlation_Agents/commodity_correlation_agent.py
@@ -4,6 +4,8 @@ from textwrap import dedent
 from src.Agents.base_agent import BaseAgent
 from src.Data_Retrieval.data_fetcher_commodity import DataFetcher
 import logging
+import pandas as pd
+
 
 class CommodityCorrelationAgent(BaseAgent):
     def __init__(self, stock: str = "AAPL", commodity: str = "OIL", **kwargs):
@@ -24,10 +26,41 @@ class CommodityCorrelationAgent(BaseAgent):
         fetcher = DataFetcher()
         stock_data = fetcher.get_stock_data(self.stock)
         commodity_data = fetcher.get_commodity_data(self.commodity)
-        
+
         logging.info(f"Data retrieved for {self.stock} and {self.commodity}")
-        correlation_coef = stock_data['Close'].corr(commodity_data['Close'])
-        
+
+        # Debug to confirm structure
+        print("Stock Data Columns:", stock_data.columns)
+        print("Commodity Data Columns:", commodity_data.columns)
+
+        # Access the Close columns for stock and commodity
+        stock_close = stock_data[f"Close_{self.stock}"]
+        commodity_close = commodity_data[f"Close_{self.commodity}"]
+
+        # Ensure they are Series
+        if isinstance(stock_close, pd.DataFrame):
+            stock_close = stock_close.squeeze()  # Converts single-column DataFrame to Series
+        if isinstance(commodity_close, pd.DataFrame):
+            commodity_close = commodity_close.squeeze()  # Converts single-column DataFrame to Series
+
+        # Debug to confirm they are Series
+        print("Type of stock_close:", type(stock_close))
+        print("Type of commodity_close:", type(commodity_close))
+        print("Stock Close Head:", stock_close.head())
+        print("Commodity Close Head:", commodity_close.head())
+
+        # Drop missing values
+        stock_close = stock_close.dropna()
+        commodity_close = commodity_close.dropna()
+
+        # Ensure lengths match
+        min_length = min(len(stock_close), len(commodity_close))
+        stock_close = stock_close.iloc[:min_length]
+        commodity_close = commodity_close.iloc[:min_length]
+
+        # Calculate correlation
+        correlation_coef = stock_close.corr(commodity_close)
+
         return crewai.Task(
             description=dedent(f"""
                 Analyze the historical price data of {self.stock} and {self.commodity} to calculate their correlation.
@@ -36,3 +69,5 @@ class CommodityCorrelationAgent(BaseAgent):
             agent=self,
             expected_output=f"The correlation between {self.stock} and {self.commodity} is: {correlation_coef:.4f}"
         )
+
+

--- a/src/Backtesting/unittest_commodity_correlation.py
+++ b/src/Backtesting/unittest_commodity_correlation.py
@@ -1,0 +1,87 @@
+import pytest
+import pandas as pd
+from datetime import datetime, timedelta
+from src.Data_Retrieval.data_fetcher_commodity import DataFetcher
+from src.Agents.Commodity_Correlation_Agents.commodity_correlation_agent import CommodityCorrelationAgent 
+from src.Agents.Commodity_Correlation_Agents.investment_decision_agent import InvestmentDecisionAgent
+from src.Indicators.commodity_correlation import CommodityCorrelationIndicator
+from src.UI.commodity_correlation_analysis import CommodityCorrelationCrew
+
+
+
+import unittest
+from unittest.mock import patch
+
+
+
+class TestDataFetcher(unittest.TestCase):
+    def setUp(self):
+        self.fetcher = DataFetcher()
+
+    def test_get_stock_data(self):
+        stock_data = self.fetcher.get_stock_data("AAPL")
+        self.assertFalse(stock_data.empty, "Stock data should not be empty")
+        self.assertIn("Close_AAPL", stock_data.columns, "Stock data should contain Close column")
+
+    def test_get_commodity_data(self):
+        commodity_data = self.fetcher.get_commodity_data("OIL")
+        self.assertFalse(commodity_data.empty, "Commodity data should not be empty")
+        self.assertIn("Close_OIL", commodity_data.columns, "Commodity data should contain Close column")
+
+    def test_get_commodity_data_invalid(self):
+        with self.assertRaises(ValueError):
+            self.fetcher.get_commodity_data("INVALID_COMMODITY")
+
+
+class TestCommodityCorrelationAgent(unittest.TestCase):
+    @patch("src.Agents.Commodity_Correlation_Agents.commodity_correlation_agent.DataFetcher.get_stock_data")
+    @patch("src.Agents.Commodity_Correlation_Agents.commodity_correlation_agent.DataFetcher.get_commodity_data")
+    def test_calculate_correlation(self, mock_commodity_data, mock_stock_data):
+        mock_stock_data.return_value = pd.DataFrame({"Close_AAPL": [100, 101, 102, 103, 104]})
+        mock_commodity_data.return_value = pd.DataFrame({"Close_OIL": [50, 51, 52, 53, 54]})
+
+        agent = CommodityCorrelationAgent(stock="AAPL", commodity="OIL")
+        task = agent.calculate_correlation()
+        self.assertIn("correlation", task.expected_output, "Expected output should include correlation")
+
+
+class TestInvestmentDecisionAgent(unittest.TestCase):
+    def test_investment_decision(self):
+        agent = InvestmentDecisionAgent(stock="AAPL", commodity="OIL")
+        task = agent.investment_decision()
+        self.assertIn("recommendation", task.expected_output.lower(), "Expected output should include recommendation")
+
+
+class TestCommodityCorrelationIndicator(unittest.TestCase):
+    def test_calculate_perfect_correlation(self):
+        stock_data = pd.DataFrame({"Close": [1, 2, 3, 4, 5]})
+        commodity_data = pd.DataFrame({"Close": [10, 20, 30, 40, 50]})
+
+        indicator = CommodityCorrelationIndicator(stock_data, commodity_data)
+        correlation = indicator.calculate()
+        self.assertEqual(correlation, 1.0, "Perfect positive correlation should be 1.0")
+
+    def test_calculate_negative_correlation(self):
+        stock_data = pd.DataFrame({"Close": [1, 2, 3, 4, 5]})
+        commodity_data = pd.DataFrame({"Close": [50, 40, 30, 20, 10]})
+
+        indicator = CommodityCorrelationIndicator(stock_data, commodity_data)
+        correlation = indicator.calculate()
+        self.assertEqual(correlation, -1.0, "Perfect negative correlation should be -1.0")
+
+
+class TestCommodityCorrelationCrew(unittest.TestCase):
+    @patch("src.Agents.Commodity_Correlation_Agents.commodity_correlation_agent.DataFetcher.get_stock_data")
+    @patch("src.Agents.Commodity_Correlation_Agents.commodity_correlation_agent.DataFetcher.get_commodity_data")
+    def test_commodity_correlation_crew(self, mock_commodity_data, mock_stock_data):
+        mock_stock_data.return_value = pd.DataFrame({"Close_AAPL": [100, 101, 102, 103, 104]})
+        mock_commodity_data.return_value = pd.DataFrame({"Close_OIL": [50, 51, 52, 53, 54]})
+
+        crew = CommodityCorrelationCrew(stock="AAPL", commodity="OIL")
+        result = crew.run()
+        self.assertIn("correlation", result, "Result should include correlation analysis")
+        self.assertIn("recommendation", result, "Result should include investment recommendations")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Data_Retrieval/data_fetcher_commodity.py
+++ b/src/Data_Retrieval/data_fetcher_commodity.py
@@ -31,31 +31,24 @@ class DataFetcher:
         end_date_str = end_date.strftime('%Y-%m-%d')
 
         df = yf.download(symbol, start=start_date_str, end=end_date_str)
+
+        # Rename columns to include the stock ticker
+        df = df.rename(columns=lambda col: f"{col}_{symbol}")
         df.index = pd.to_datetime(df.index)
         return df
 
+
     def get_commodity_data(self, commodity: str, start_date: datetime = None, end_date: datetime = None) -> pd.DataFrame:
-        """
-        Fetches historical commodity data for the given commodity.
-
-        Args:
-            commodity (str): The commodity to fetch data for (e.g., "OIL", "GOLD").
-
-        Returns:
-            pd.DataFrame: A DataFrame containing the historical commodity data.
-        """
-        # Mapping commodity names to Yahoo Finance symbols
         commodity_symbols = {
             "OIL": "CL=F",     # Crude Oil WTI
             "GOLD": "GC=F"     # Gold
         }
-        
+
         if commodity not in commodity_symbols:
             raise ValueError(f"Unsupported commodity: {commodity}")
 
         symbol = commodity_symbols[commodity]
-        
-        # Use provided dates or default to initialization dates
+
         if start_date is None:
             start_date = self.start_date
         if end_date is None:
@@ -65,5 +58,8 @@ class DataFetcher:
         end_date_str = end_date.strftime('%Y-%m-%d')
 
         df = yf.download(symbol, start=start_date_str, end=end_date_str)
+
+        # Ensure columns have a consistent name format
+        df = df.rename(columns=lambda col: f"{col}_{commodity}")
         df.index = pd.to_datetime(df.index)
         return df


### PR DESCRIPTION
[US15.5: Create unit and integration tests for stock-commodity correlation calculations and ChatGPT recommendations (7 person-hours). #176](https://github.com/Rivier-Computer-Science/AI-Agent-Stock-Prediction/issues/176)