### PR TITLE
Trix indicator Sprint 1

### DIFF
--- a/src/Indicators/trix.py
+++ b/src/Indicators/trix.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+def calculate_trix(df: pd.DataFrame, length: int = 14, signal: int = 9) -> pd.DataFrame:
+    """
+    Calculates the TRIX (Triple-Smoothed Exponential Moving Average) indicator and
+    its signal line.
+
+    Parameters:
+        df (pd.DataFrame): DataFrame containing 'Close' prices.
+        length (int): The EMA length for each of the triple smoothings.
+        signal (int): The EMA period to compute the TRIX signal line.
+
+    Returns:
+        pd.DataFrame: The original DataFrame with two new columns:
+                      - 'TRIX': TRIX values.
+                      - 'TRIX_SIGNAL': Signal line of the TRIX.
+    """
+    # 1st smoothing
+    ema1 = df['Close'].ewm(span=length, adjust=False).mean()
+    # 2nd smoothing
+    ema2 = ema1.ewm(span=length, adjust=False).mean()
+    # 3rd smoothing
+    ema3 = ema2.ewm(span=length, adjust=False).mean()
+
+    # TRIX = 100 * (current_ema3 - previous_ema3) / previous_ema3
+    df['TRIX'] = (ema3 - ema3.shift(1)) / ema3.shift(1) * 100
+
+    # Signal line is often an EMA of the TRIX values
+    df['TRIX_SIGNAL'] = df['TRIX'].ewm(span=signal, adjust=False).mean()
+
+    return df

--- a/src/UI/trix_main.py
+++ b/src/UI/trix_main.py
@@ -9,8 +9,8 @@ import pandas as pd
 #from src.Data_Retrieval.data_fetcher import DataFetcher
 #from src.Indicators.trix import calculate_trix
 
-from Data_Retrieval.data_fetcher import DataFetcher
-from Indicators.trix import calculate_trix
+from Chadalavada-AI-Agent-Stock-Prediction.src.Data_Retrieval.data_fetcher import DataFetcher
+from Chadalavada-AI-Agent-Stock-Prediction.src.Indicators.trix import calculate_trix
 
 st.title("TRIX Indicator Calculation")
 

--- a/src/UI/trix_main.py
+++ b/src/UI/trix_main.py
@@ -6,8 +6,11 @@ import streamlit as st
 import pandas as pd
 
 # Import your existing modules
-from src.Data_Retrieval.data_fetcher import DataFetcher
-from src.Indicators.trix import calculate_trix
+#from src.Data_Retrieval.data_fetcher import DataFetcher
+#from src.Indicators.trix import calculate_trix
+
+from Data_Retrieval.data_fetcher import DataFetcher
+from Indicators.trix import calculate_trix
 
 st.title("TRIX Indicator Calculation")
 

--- a/src/UI/trix_main.py
+++ b/src/UI/trix_main.py
@@ -9,8 +9,8 @@ import pandas as pd
 #from src.Data_Retrieval.data_fetcher import DataFetcher
 #from src.Indicators.trix import calculate_trix
 
-from Chadalavada-AI-Agent-Stock-Prediction.src.Data_Retrieval.data_fetcher import DataFetcher
-from Chadalavada-AI-Agent-Stock-Prediction.src.Indicators.trix import calculate_trix
+from src.Data_Retrieval.data_fetcher import DataFetcher
+from src.Indicators.trix import calculate_trix
 
 st.title("TRIX Indicator Calculation")
 

--- a/src/UI/trix_main.py
+++ b/src/UI/trix_main.py
@@ -1,0 +1,35 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+import streamlit as st
+import pandas as pd
+
+# Import your existing modules
+from src.Data_Retrieval.data_fetcher import DataFetcher
+from src.Indicators.trix import calculate_trix
+
+st.title("TRIX Indicator Calculation")
+
+# --- 1. User Input for Symbol ---
+symbol = st.text_input("Enter Stock Symbol:", value="AAPL")
+
+# --- 2. Fetch Stock Data ---
+data_fetcher = DataFetcher()
+data = data_fetcher.get_stock_data(symbol)
+
+# Display the fetched stock data
+st.write(f"Fetched Stock Data for {symbol}:")
+st.dataframe(data.tail())
+
+# --- 3. Inputs for TRIX Calculation ---
+trix_length = st.number_input("Enter TRIX Length:", min_value=1, max_value=100, value=14, key="trix_length")
+trix_signal = st.number_input("Enter TRIX Signal Period:", min_value=1, max_value=100, value=9, key="trix_signal")
+
+# --- 4. Calculate TRIX and Display ---
+if st.button("Calculate TRIX"):
+    # Copy data to avoid modifying the original DataFrame
+    data_with_trix = calculate_trix(data.copy(), length=trix_length, signal=trix_signal)
+    st.write(f"TRIX Calculation Results for {symbol}:")
+    st.dataframe(data_with_trix.tail())
+


### PR DESCRIPTION
This pull request introduces a TRIX (Triple-Smoothed EMA) indicator calculation and it enables users to:

Fetch historical stock data via the DataFetcher class.
Calculate the TRIX indicator and its corresponding signal line using a triple-smoothed EMA approach.
Visualize TRIX values within the Streamlit UI for real-time analysis and decision-making.

**Changes in This PR**
**New calculate_trix Function (in src/Indicators/trix.py):**
Implements triple EMA smoothing of the closing price.
Computes the TRIX as the rate of change of the triple-smoothed EMA.
Includes an optional signal line calculation (e.g., a 9-period EMA of TRIX).

**New Streamlit App Logic (main_trix_app.py):**
Fetches data for a user-defined stock symbol using DataFetcher.
Accepts TRIX length and signal period as inputs from the user.
Displays a DataFrame that includes the newly computed TRIX and TRIX signal values.
Provides a button to refresh data on-demand.

**Minor Adjustments to Project Structure:**
Added trix.py in the src/Indicators folder for better modularization.
Updated imports in the Streamlit app to reference the TRIX function correctly.