### PR TITLE
RDNN.1 Implement trading environment

### DIFF
--- a/src/Backtesting/rdnn_testing.py
+++ b/src/Backtesting/rdnn_testing.py
@@ -1,0 +1,54 @@
+import pytest
+import numpy as np
+from src.UI.rdnn import TradingEnv, fetch_ohlcv
+
+
+def make_dummy_data(n_steps=100):
+    o = np.linspace(1, n_steps, n_steps)
+    h = o + 1
+    l = o - 1
+    c = o
+    v = np.ones(n_steps)
+    return np.stack([o, h, l, c, v], axis=1)
+
+
+def test_env_reset_and_step():
+    data = make_dummy_data()
+    env = TradingEnv(data, window_size=5, transaction_cost=0.0, slippage=0.0)
+    obs = env.reset()
+    assert obs.shape == (5, 5)
+    obs, reward, done, info = env.step(2)
+    assert isinstance(reward, float)
+    assert not done
+    assert "net_worth" in info
+
+
+def test_transaction_cost_and_slippage():
+    data = make_dummy_data()
+    cost = 0.01
+    env = TradingEnv(data, window_size=5, transaction_cost=cost, slippage=cost)
+    env.reset()
+    _, r1, _, _ = env.step(2)
+    _, r2, _, _ = env.step(0)
+    assert r1 < 0
+    assert r2 < 0
+
+
+def test_fetch_ohlcv_structure(monkeypatch):
+    # Monkeypatch yf.download to return a dummy DataFrame
+    import pandas as pd
+    dates = pd.date_range(start='2020-01-01', periods=10, freq='D')
+    df = pd.DataFrame({
+        'Open': np.arange(10),
+        'High': np.arange(1, 11),
+        'Low': np.arange(-1, 9),
+        'Close': np.arange(0, 10),
+        'Volume': np.ones(10)
+    }, index=dates)
+    monkeypatch.setattr('yfinance.download', lambda ticker, period, interval: df)
+    arr = fetch_ohlcv('TEST', period='1mo', interval='1d')
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (10, 5)
+
+if __name__ == "__main__":
+    pytest.main()

--- a/src/UI/rdnn.py
+++ b/src/UI/rdnn.py
@@ -1,0 +1,103 @@
+import gym
+from gym import spaces
+import numpy as np
+import yfinance as yf
+
+class TradingEnv(gym.Env):
+    """
+    Gym environment for trading based on OHLCV data.
+    Observation: window of last T bars (OHLCV).
+    Action space: 0=SELL, 1=HOLD, 2=BUY.
+    Reward: change in portfolio value minus transaction cost and slippage.
+    """
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, data, window_size=10, transaction_cost=0.001, slippage=0.001):
+        super(TradingEnv, self).__init__()
+        # data: NumPy array of shape (n_steps, 5) representing OHLCV
+        self.data = np.array(data, dtype=np.float32)
+        self.window_size = window_size
+        self.transaction_cost = transaction_cost
+        self.slippage = slippage
+
+        # define action and observation spaces
+        self.action_space = spaces.Discrete(3)
+        obs_shape = (window_size, self.data.shape[1])
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=obs_shape, dtype=np.float32
+        )
+        self.reset()
+
+    def reset(self):
+        # start at the first point where we have a full window
+        self.current_step = self.window_size
+        self.position = 0
+        self.entry_price = 0.0
+        self.net_worth = 1.0
+        return self._get_observation()
+
+    def _get_observation(self):
+        return self.data[self.current_step - self.window_size : self.current_step]
+
+    def step(self, action):
+        done = False
+        price = self.data[self.current_step, 3]  # use close price
+        reward = 0.0
+
+        # execute action: SELL (0), HOLD (1), BUY (2)
+        if action == 0 and self.position != -1:
+            reward -= self._cost(price)
+            self.position = -1
+            self.entry_price = price
+        elif action == 2 and self.position != 1:
+            reward -= self._cost(price)
+            self.position = 1
+            self.entry_price = price
+
+        # calculate P&L and reward
+        pnl = self.position * (price - self.entry_price)
+        reward += pnl
+        self.net_worth += pnl - self._cost(price)
+
+        # advance step
+        self.current_step += 1
+        if self.current_step >= len(self.data):
+            done = True
+
+        obs = self._get_observation() if not done else np.zeros_like(self._get_observation())
+        info = {"net_worth": self.net_worth}
+        return obs, reward, done, info
+
+    def _cost(self, price):
+        # simple transaction cost + slippage
+        return price * (self.transaction_cost + self.slippage)
+
+    def render(self, mode="human"):
+        print(f"Step: {self.current_step}, Position: {self.position}, Net worth: {self.net_worth:.3f}")
+
+
+def fetch_ohlcv(ticker: str, period: str = "1y", interval: str = "1d") -> np.ndarray:
+    """
+    Fetch historical OHLCV data for a given ticker using yfinance.
+    Returns a NumPy array of shape (n_steps, 5) with columns [Open, High, Low, Close, Volume].
+    """
+    df = yf.download(ticker, period=period, interval=interval)
+    df = df.dropna()
+    df = df[["Open", "High", "Low", "Close", "Volume"]]
+    return df.values
+
+if __name__ == "__main__":
+    ticker = input("Enter stock ticker symbol (e.g., AAPL): ").strip().upper()
+    try:
+        data_array = fetch_ohlcv(ticker)
+        print(f"Fetched {data_array.shape[0]} rows of OHLCV data for {ticker}.")
+    except Exception as e:
+        print(f"Error fetching data for {ticker}: {e}")
+        exit(1)
+
+    window_size = 10
+    env = TradingEnv(data_array, window_size=window_size)
+    obs = env.reset()
+    print(f"Initial observation shape: {obs.shape}")
+    next_obs, reward, done, info = env.step(1)
+    print(f"After one step => reward: {reward:.4f}, net_worth: {info['net_worth']:.4f}")


### PR DESCRIPTION
[RDNN.1 Implement Trading Environment #591](https://github.com/Rivier-Computer-Science/AI-Agent-Stock-Prediction/issues/591)

This pull request introduces a new Gym-compatible TradingEnv class that retrieves real OHLCV data via yfinance and provides step-wise trading logic (SELL, HOLD, BUY) with transaction-cost/slippage modeling. It also includes accompanying unit tests to verify environment behavior and the OHLCV fetching functionality.

1. New file: src/UI/trading_env.py
fetch_ohlcv(ticker, period, interval)

Prompts the user for a stock ticker (e.g., AAPL) when run as a script

Uses yfinance.download to retrieve historical OHLCV (Open, High, Low, Close, Volume) data as a NumPy array

TradingEnv class

Inherits from gym.Env

Observation: A sliding window of the last T bars (each bar has [O, H, L, C, V])

Action space: Discrete {0=SELL, 1=HOLD, 2=BUY}

Reward calculation:

Applies transaction cost + slippage whenever position changes

Computes P&L based on entry price and current close price

Updates net_worth accordingly

Implements Gym methods:

reset(): Initializes current_step, position, entry_price, and net_worth

step(action): Executes SELL/HOLD/BUY, calculates reward, advances the timestamp, returns (obs, reward, done, info)

_cost(price): Helper for transaction‐cost + slippage

render(): Prints step index, position, and net_worth

Standalone script behavior (when __main__)

Prompts user for a ticker symbol

Calls fetch_ohlcv to download data and prints the number of rows fetched

Instantiates TradingEnv with a default window size of 10

Performs one example step(1) (HOLD) and prints the resulting reward and net worth

2. New file: tests/test_trading_env.py
make_dummy_data(n_steps)

Generates synthetic OHLCV data to test environment logic without external dependencies

test_env_reset_and_step()

Verifies that reset() returns an observation of shape (window_size, 5)

Executes a single step(2) (BUY) and checks that:

Reward is a float

done flag is False (since we haven’t reached the end)

info contains a "net_worth" key

test_transaction_cost_and_slippage()

Initializes environment with nonzero transaction cost/slippage

Executes step(2) then step(0) (BUY then SELL) and asserts that each step yields a negative reward (due to cost deductions)

test_fetch_ohlcv_structure(monkeypatch)

Monkey-patches yfinance.download to return a dummy pandas DataFrame of length 10

Calls fetch_ohlcv("TEST", period="1mo", interval="1d") and verifies the returned object is a NumPy array of shape (10, 5)

Real OHLCV Data Integration:
In order to train or backtest an RL agent on actual stock market data, we must retrieve historical OHLCV bars. The fetch_ohlcv helper leverages yfinance and ensures missing values are dropped, returning a clean NumPy array for easy consumption by the environment.

Gym-Compatible Environment:
The TradingEnv class encapsulates basic trade execution logic (BUY/SELL/HOLD) with cost modeling. This completes RDNN.1 tasks:

RDNN.1.1: Defines a Gym Env with correct observation/action spaces.

RDNN.1.2: Incorporates transaction cost + slippage in _cost().

RDNN.1.3: Includes PyTest unit tests to validate state transitions, cost application, and reward structure.

Test Coverage:
These tests provide confidence that:

The environment’s reset/step mechanics behave as intended.

Transaction cost and slippage are correctly subtracted from the reward when changing positions.

fetch_ohlcv returns a properly structured NumPy array even if the external data source changes.