### PR TITLE
NQR Datafetch and ratio calculation

### DIFF
--- a/src/Backtesting/nqr_unit_tests.py
+++ b/src/Backtesting/nqr_unit_tests.py
@@ -1,0 +1,54 @@
+import pytest
+import pandas as pd
+import yfinance as yf
+from src.UI.nqr import DataFetch, RatioCalc
+
+class DummyTicker:
+    def __init__(self, income_df, balance_df):
+        self.quarterly_financials = income_df
+        self.quarterly_balance_sheet = balance_df
+
+@pytest.fixture(autouse=True)
+def patch_yfinance(monkeypatch):
+    # Create dummy quarterly_financials: index = ["Total Revenue","Net Income"], columns = [pd.Timestamp]
+    date = pd.Timestamp("2023-03-31")
+    inc_df = pd.DataFrame(
+        {"Total Revenue": [500], "Net Income": [100]},
+        index=[date]
+    )
+    # Transpose to match yfinance structure: index metrics, columns date
+    inc_df = inc_df.transpose()
+    # Create dummy quarterly_balance_sheet: index = ["Total Stockholder Equity","Total Liab"], columns = [pd.Timestamp]
+    bs_df = pd.DataFrame(
+        {"Total Stockholder Equity": [200], "Total Liab": [300]},
+        index=[date]
+    )
+    bs_df = bs_df.transpose()
+    def mock_ticker(ticker):
+        return DummyTicker(inc_df, bs_df)
+    monkeypatch.setattr(yf, 'Ticker', mock_ticker)
+
+def test_fetch_income_statement():
+    df = DataFetch(num_quarters=1)
+    reports = df.fetch_income_statement('AAPL')
+    assert isinstance(reports, list)
+    assert reports[0]['fiscalDateEnding'] == '2023-03-31'
+    assert reports[0]['totalRevenue'] == 500
+    assert reports[0]['netIncome'] == 100
+
+def test_fetch_balance_sheet():
+    df = DataFetch(num_quarters=1)
+    reports = df.fetch_balance_sheet('AAPL')
+    assert isinstance(reports, list)
+    assert reports[0]['fiscalDateEnding'] == '2023-03-31'
+    assert reports[0]['totalShareholderEquity'] == 200
+    assert reports[0]['totalLiabilities'] == 300
+
+def test_compute_ratios():
+    income_reports = [{'fiscalDateEnding': '2023-03-31', 'totalRevenue': 500, 'netIncome': 100}]
+    balance_reports = [{'fiscalDateEnding': '2023-03-31', 'totalShareholderEquity': 200, 'totalLiabilities': 300}]
+    rc = RatioCalc()
+    ratios = rc.compute_ratios(income_reports, balance_reports)
+    assert abs(ratios[0]['roe'] - 0.5) < 1e-6
+    assert abs(ratios[0]['debt_equity'] - 1.5) < 1e-6
+    assert abs(ratios[0]['net_profit_margin'] - 0.2) < 1e-6

--- a/src/UI/nqr.py
+++ b/src/UI/nqr.py
@@ -1,0 +1,105 @@
+import yfinance as yf
+import sys
+import os
+
+class DataFetch:
+    """
+    Fetch quarterly financial statements for a given ticker via yfinance.
+    """
+    def __init__(self, num_quarters: int = 10):
+        self.num_quarters = num_quarters
+
+    def fetch_income_statement(self, ticker: str) -> list:
+        """
+        Returns a list of dictionaries—each dict is one quarter's P&L.
+        """
+        tk = yf.Ticker(ticker)
+        inc_df = tk.quarterly_financials.transpose()
+        # Sort by fiscal date descending
+        inc_df = inc_df.sort_index(ascending=False)
+        # Take top num_quarters rows
+        top_inc = inc_df.head(self.num_quarters)
+        records = []
+        for idx, row in top_inc.iterrows():
+            records.append({
+                "fiscalDateEnding": idx.strftime("%Y-%m-%d"),
+                "totalRevenue": row.get("Total Revenue", None),
+                "netIncome": row.get("Net Income", None),
+            })
+        if not records:
+            raise ValueError(f"No income statement data found for {ticker}")
+        return records
+
+    def fetch_balance_sheet(self, ticker: str) -> list:
+        """
+        Returns a list of dictionaries—each dict is one quarter's B/S.
+        """
+        tk = yf.Ticker(ticker)
+        bs_df = tk.quarterly_balance_sheet.transpose()
+        bs_df = bs_df.sort_index(ascending=False)
+        top_bs = bs_df.head(self.num_quarters)
+        records = []
+        for idx, row in top_bs.iterrows():
+            records.append({
+                "fiscalDateEnding": idx.strftime("%Y-%m-%d"),
+                "totalShareholderEquity": row.get("Total Stockholder Equity", None),
+                "totalLiabilities": row.get("Total Liab", None),
+            })
+        if not records:
+            raise ValueError(f"No balance sheet data found for {ticker}")
+        return records
+
+class RatioCalc:
+    """
+    Compute financial ratios (ROE, debt/equity, net profit margin) from raw statements.
+    """
+    def compute_ratios(self, income_reports: list, balance_reports: list) -> list:
+        """
+        Given lists of income and balance reports (aligned by quarter), computes:
+        - ROE = netIncome / totalShareholderEquity
+        - Debt/Equity = totalLiabilities / totalShareholderEquity
+        - Net Profit Margin = netIncome / totalRevenue
+        Returns a list of dicts with 'fiscalDateEnding' and computed ratios.
+        """
+        ratios = []
+        for inc, bal in zip(income_reports, balance_reports):
+            try:
+                net_inc = float(inc.get('netIncome', 0) or 0)
+                rev = float(inc.get('totalRevenue', 0) or 0)
+                equity = float(bal.get('totalShareholderEquity', 0) or 0)
+                liabilities = float(bal.get('totalLiabilities', 0) or 0)
+            except (TypeError, ValueError):
+                net_inc = rev = equity = liabilities = 0.0
+            roe = net_inc / equity if equity else None
+            debt_equity = liabilities / equity if equity else None
+            net_profit_margin = net_inc / rev if rev else None
+            ratios.append({
+                'fiscalDateEnding': inc.get('fiscalDateEnding'),
+                'roe': roe,
+                'debt_equity': debt_equity,
+                'net_profit_margin': net_profit_margin
+            })
+        return ratios
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        ticker = sys.argv[1].strip().upper()
+    else:
+        ticker = input("Enter stock ticker symbol: ").strip().upper()
+    df = DataFetch()
+    rc = RatioCalc()
+
+    try:
+        income_reports = df.fetch_income_statement(ticker)
+        balance_reports = df.fetch_balance_sheet(ticker)
+    except Exception as e:
+        print(f"Error fetching data for {ticker}: {e}")
+        sys.exit(1)
+
+    ratios = rc.compute_ratios(income_reports, balance_reports)
+    print(f"Ratios for {ticker}:")
+    for r in ratios:
+        print(
+            f"Date: {r['fiscalDateEnding']} | ROE: {r['roe']} | "
+            f"Debt/Equity: {r['debt_equity']} | Net Profit Margin: {r['net_profit_margin']}"
+        )


### PR DESCRIPTION
[NQR.1 Ratio Data Retrieval & Preparation #598](https://github.com/Rivier-Computer-Science/AI-Agent-Stock-Prediction/issues/598)

This PR adds a new module for fetching quarterly financial data via yfinance, computing key financial ratios, and corresponding unit tests.

Changes

pipeline_agents.py

Introduces DataFetch class to retrieve the most recent num_quarters of quarterly income statements and balance sheets from yfinance.

fetch_income_statement(ticker) returns a list of {fiscalDateEnding, totalRevenue, netIncome}.

fetch_balance_sheet(ticker) returns a list of {fiscalDateEnding, totalShareholderEquity, totalLiabilities}.

Raises a ValueError if no data is found.

Adds RatioCalc class to compute:

ROE = netIncome / totalShareholderEquity

Debt/Equity = totalLiabilities / totalShareholderEquity

Net Profit Margin = netIncome / totalRevenue

test_pipeline_agents.py

Mocks yfinance.Ticker using pytest’s monkeypatch and pandas to create dummy DataFrames for one quarter (revenue=500, netIncome=100; equity=200, liabilities=300).

Verifies:

fetch_income_statement returns a list containing the correct fiscalDateEnding, totalRevenue, and netIncome.

fetch_balance_sheet returns a list containing the correct fiscalDateEnding, totalShareholderEquity, and totalLiabilities.

compute_ratios calculates ROE=0.5, Debt/Equity=1.5, and Net Profit Margin=0.2.