### PR TITLE
RDNN.4 and RDDN.5 Add validation-based early stopping and inference API enhancements

### DIFF
--- a/src/UI/rdnn.py
+++ b/src/UI/rdnn.py
@@ -4,10 +4,12 @@ import numpy as np
 import yfinance as yf
 import torch
 import torch.nn as nn
+import time
+import json
 
 # RDNN.3 imports
 from sb3_contrib import RecurrentPPO
-from stable_baselines3.common.callbacks import EvalCallback
+from stable_baselines3.common.callbacks import EvalCallback, StopTrainingOnNoModelImprovement
 
 class TradingEnv(gym.Env):
     """
@@ -19,22 +21,18 @@ class TradingEnv(gym.Env):
     metadata = {"render.modes": ["human"]}
 
     def __init__(self, data, window_size=10, transaction_cost=0.001, slippage=0.001):
-        super(TradingEnv, self).__init__()
-        # RDNN.1.1: store OHLCV data
+        super().__init__()
         self.data = np.array(data, dtype=np.float32)
         self.window_size = window_size
-        # RDNN.1.2: cost and slippage settings
         self.transaction_cost = transaction_cost
         self.slippage = slippage
 
-        # Define action/observation spaces
         self.action_space = spaces.Discrete(3)
         obs_shape = (window_size, self.data.shape[1])
-        self.observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=obs_shape, dtype=np.float32)
+        self.observation_space = spaces.Box(-np.inf, np.inf, obs_shape, dtype=np.float32)
         self.reset()
 
     def reset(self):
-        # RDNN.1.1: reset environment state
         self.current_step = self.window_size
         self.position = 0
         self.entry_price = 0.0
@@ -42,27 +40,23 @@ class TradingEnv(gym.Env):
         return self._get_observation()
 
     def _get_observation(self):
-        # RDNN.1.1: return last T bars
         return self.data[self.current_step - self.window_size : self.current_step]
 
     def step(self, action):
-        # RDNN.1.2: apply action, compute reward with costs
         done = False
         price = self.data[self.current_step, 3]
         reward = 0.0
-        # SELL
+
         if action == 0 and self.position != -1:
             reward -= self._cost(price)
             self.position = -1
             self.entry_price = price
-        # BUY
         elif action == 2 and self.position != 1:
             reward -= self._cost(price)
             self.position = 1
             self.entry_price = price
         # HOLD does nothing
 
-        # Calculate P&L
         pnl = self.position * (price - self.entry_price)
         reward += pnl
         self.net_worth += pnl - self._cost(price)
@@ -75,33 +69,22 @@ class TradingEnv(gym.Env):
         return obs, reward, done, {"net_worth": self.net_worth}
 
     def _cost(self, price):
-        # RDNN.1.2: simple transaction cost + slippage
         return price * (self.transaction_cost + self.slippage)
 
     def render(self, mode="human"):
-        # RDNN.1.3: render state
         print(f"Step: {self.current_step}, Position: {self.position}, Net worth: {self.net_worth:.3f}")
 
-
 def fetch_ohlcv(ticker: str, period: str = "1y", interval: str = "1d") -> np.ndarray:
-    """
-    Fetch OHLCV data with yfinance (RDNN.1).
-    Returns array with columns [Open, High, Low, Close, Volume].
-    """
     df = yf.download(ticker, period=period, interval=interval)
     df = df.dropna()[["Open", "High", "Low", "Close", "Volume"]]
     return df.values
 
-# ===== RDNN.2: Build RNN Policy Network =====
-# RDNN.2.1: LSTM encoder
-# RDNN.2.2: DQN & PPO heads
-# RDNN.2.3: dummy forward-pass
 class RNNPolicyNetwork(nn.Module):
     """
     LSTM-based encoder with DQN and PPO heads.
     """
     def __init__(self, input_size, hidden_size, num_layers, action_dim):
-        super(RNNPolicyNetwork, self).__init__()
+        super().__init__()
         self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True)
         self.q_head = nn.Linear(hidden_size, action_dim)
         self.policy_head = nn.Linear(hidden_size, action_dim)
@@ -111,53 +94,118 @@ class RNNPolicyNetwork(nn.Module):
         lstm_out, hidden_out = self.lstm(x, hidden)
         last = lstm_out[:, -1, :]
         return (
-            self.q_head(last),        # Q-values
-            self.policy_head(last),   # policy logits
-            self.value_head(last),    # state-value
+            self.q_head(last),
+            self.policy_head(last),
+            self.value_head(last),
             hidden_out
         )
 
-# ===== RDNN.3: Configure RL Algorithm =====
-# RDNN.3.1: integrate RecurrentPPO
-# RDNN.3.2: set/document hyperparameters
-# RDNN.3.3: TensorBoard/EvalCallback logging
-
 def train_recurrent_ppo(env, total_timesteps=10000, log_dir='./logs/'):
-    """
-    Train a RecurrentPPO agent on TradingEnv.
-
-    Hyperparameters (RDNN.3.2):
-      - learning_rate: 3e-4
-      - batch_size: 64
-      - n_steps: 256
-      - tensorboard_log: log_dir  (RDNN.3.3)
-    """
-    hyperparams = {
-        'learning_rate': 3e-4,
-        'batch_size': 64,
-        'n_steps': 256,
-        'tensorboard_log': log_dir,
-    }
     model = RecurrentPPO(
         policy='MlpLstmPolicy',
         env=env,
         verbose=1,
-        **hyperparams
+        learning_rate=3e-4,
+        batch_size=64,
+        n_steps=256,
+        tensorboard_log=log_dir,
     )
-    eval_callback = EvalCallback(
+    eval_cb = EvalCallback(
         env,
-        best_model_save_path='./best_model/',
+        best_model_save_path='./best_model/rdnn3/',
         log_path=log_dir,
         eval_freq=100_000,
         n_eval_episodes=1
-    )  # RDNN.3.3: logging & evaluation
-    model.learn(total_timesteps=total_timesteps, tb_log_name='rdnn3', callback=eval_callback)
+    )
+    model.learn(total_timesteps=total_timesteps, tb_log_name='rdnn3', callback=eval_cb)
     model.save('rdnn3_recurrentppo')
     return model
 
+def train_recurrent_ppo_with_validation(train_env, eval_env, total_timesteps=50000, log_dir='./logs/rdnn4/'):
+    stop_cb = StopTrainingOnNoModelImprovement(
+        max_no_improvement_evals=5,
+        min_evals=5,
+        verbose=1
+    )
+    eval_cb = EvalCallback(
+        eval_env,
+        best_model_save_path='./best_model/rdnn4/',
+        log_path=log_dir,
+        eval_freq=5000,
+        n_eval_episodes=5,
+        callback_after_eval=stop_cb
+    )
+    model = RecurrentPPO(
+        policy='MlpLstmPolicy',
+        env=train_env,
+        verbose=1,
+        learning_rate=3e-4,
+        batch_size=64,
+        n_steps=256,
+        tensorboard_log=log_dir,
+    )
+    model.learn(total_timesteps=total_timesteps, tb_log_name='rdnn4', callback=eval_cb)
+    model.save('rdnn4_recurrentppo')
+    return model
+
+class InferenceAgent:
+    """
+    Loads a trained policy and provides action probability inference.
+    """
+    def __init__(self, model_path):
+        self.model = RecurrentPPO.load(model_path)
+        self.hidden_state = None
+
+    def infer(self, window: np.ndarray) -> str:
+        # build numpy episode_start mask
+        episode_starts_np = np.array([self.hidden_state is None], dtype=bool)
+
+        # init or carry over hidden state
+        obs_batch = window[np.newaxis, ...]
+        _, self.hidden_state = self.model.predict(
+            obs_batch,
+            state=self.hidden_state,
+            episode_start=episode_starts_np
+        )
+
+        # prepare torch tensors
+        obs_tensor = torch.tensor(window, dtype=torch.float32).unsqueeze(0)
+        ep_tensor = torch.tensor(episode_starts_np, dtype=torch.float32, device=obs_tensor.device)
+
+        # get distribution & new states
+        dist, new_states = self.model.policy.get_distribution(
+            obs_tensor,
+            self.hidden_state,
+            ep_tensor
+        )
+        self.hidden_state = new_states
+
+        # detach before numpy
+        probs = dist.distribution.probs.detach().cpu().numpy()[0].tolist()
+        return json.dumps({"action_probs": probs})
+
+    def benchmark(self, window: np.ndarray, n_runs: int = 100) -> float:
+        obs_tensor = torch.tensor(window, dtype=torch.float32).unsqueeze(0)
+        # warm-up
+        _ = self.model.policy.get_distribution(
+            obs_tensor,
+            self.hidden_state or np.array([True], dtype=bool),
+            torch.tensor([0.0], dtype=torch.float32, device=obs_tensor.device)
+        )
+        start = time.time()
+        for _ in range(n_runs):
+            with torch.no_grad():
+                _ = self.model.policy.get_distribution(
+                    obs_tensor,
+                    self.hidden_state,
+                    torch.tensor([0.0], dtype=torch.float32, device=obs_tensor.device)
+                )
+        latency = (time.time() - start) / n_runs
+        print(f"Average inference latency: {latency*1000:.3f} ms")
+        return latency
+
 if __name__ == '__main__':
     ticker = input('Enter stock ticker symbol (e.g., AAPL): ').strip().upper()
-    # Fetch and run simple demo
     try:
         data_array = fetch_ohlcv(ticker)
         print(f'Fetched {data_array.shape[0]} rows of OHLCV data for {ticker}.')
@@ -165,19 +213,16 @@ if __name__ == '__main__':
         print(f'Error fetching data for {ticker}: {e}')
         exit(1)
 
-    # RDNN.1 demonstration
     window_size = 10
-    env = TradingEnv(data_array, window_size=window_size)
-    obs = env.reset()
-    print(f'Initial observation shape: {obs.shape}')
-    next_obs, reward, done, info = env.step(1)
-    print(f'After one step => reward: {reward:.4f}, net_worth: {info['net_worth']:.4f}')
+    split_idx = int(len(data_array) * 0.8)
+    train_data = data_array[:split_idx]
+    test_data  = data_array[split_idx - window_size:]
+    train_env  = TradingEnv(train_data, window_size=window_size)
+    eval_env   = TradingEnv(test_data,  window_size=window_size)
 
-    # RDNN.2.3: dummy forward-pass test
-    dummy_obs = torch.randn(2, window_size, data_array.shape[1])
-    net = RNNPolicyNetwork(input_size=data_array.shape[1], hidden_size=64, num_layers=1, action_dim=3)
-    q, pi, v, _ = net(dummy_obs)
-    print(f'Shapes Q:{q.shape} Pi:{pi.shape} V:{v.shape}')
+    model = train_recurrent_ppo_with_validation(train_env, eval_env)
 
-    # RDNN.3 training
-    train_recurrent_ppo(env)
+    agent = InferenceAgent('./best_model/rdnn4/best_model.zip')
+    sample_window = test_data[:window_size]
+    print(f'Action probabilities: {agent.infer(sample_window)}')
+    agent.benchmark(sample_window, n_runs=500)


### PR DESCRIPTION
[RDNN.4 Train](https://github.com/Rivier-Computer-Science/AI-Agent-Stock-Prediction/issues/672)

[RDNN.5 Develop Inference API](https://github.com/Rivier-Computer-Science/AI-Agent-Stock-Prediction/issues/676)

This PR implements two major features in the Recurrent PPO workflow:

RDNN.4 – Training with Validation & Early Stopping

Integrate a hold-out evaluation environment during training.

Use StopTrainingOnNoModelImprovement to halt training after 5 non-improving evaluation rounds.

Save best model checkpoints under ./best_model/rdnn4/.

Log metrics and evaluation performance every 5 000 steps.

RDNN.5 – Inference Agent & Action-Probability API

Introduce InferenceAgent class that:

Loads the trained RecurrentPPO model.

Manages recurrent LSTM hidden state across calls via episode_start masks.

Exposes an infer(window) method returning JSON-formatted action probabilities.

Ensure tensors are properly detached before converting to NumPy to avoid gradient errors.

Add a benchmark helper to measure average inference latency.

Testing & Validation

Trained on sample stock data; verified early stopping triggers after no validation improvement.

Called InferenceAgent.infer(...) on a sample window; confirmed correct JSON output and no runtime errors.

Ran benchmark(...) to ensure inference latency reports successfully.