### PR TITLE
TRF.4 and TRF.5 Add XGBoost training and end-to-end inference pipeline

### DIFF
--- a/src/UI/trf.py
+++ b/src/UI/trf.py
@@ -1,17 +1,24 @@
 import os
+import json
 import yfinance as yf
 import pandas as pd
 import numpy as np
-from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import StandardScaler
+import joblib
+import xgboost as xgb
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader, TensorDataset
+import torch.nn.functional as F
 
+from sklearn.model_selection import train_test_split, GridSearchCV
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import DataLoader, TensorDataset
+import warnings
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
 # #########################
-# 1. TRF.1: DataAgent
+# 1. TRF.1: DataHandler
 # #########################
-class DataAgent:
+class DataHandler:
     """
     Handles data ingestion and preprocessing for OHLCV data.
     """
@@ -30,9 +37,7 @@ class DataAgent:
             end=self.end_date,
             progress=False
         )
-        # Keep only the 'Close' column
-        df = df[['Close']].dropna()
-        return df
+        return df[['Close']].dropna()
 
     def impute_and_align(self, df):
         """Fill missing data and ensure datetime index."""
@@ -48,23 +53,21 @@ class DataAgent:
 
     def create_windows(self, df, test_size=0.2, val_size=0.1):
         """
-        Build 20-day windows and labels (1 if next-day price up, else 0),
+        Build windows and labels (1 if next-day price up, else 0),
         then split into train/val/test.
         """
         X, y = [], []
         for i in range(len(df) - self.window_size - 1):
-            window = df.iloc[i:i+self.window_size].values
-            # label based on next-day movement
-            label = 1 if df.iloc[i+self.window_size+1, 0] > df.iloc[i+self.window_size, 0] else 0
+            window = df.iloc[i : i + self.window_size].values
+            label = 1 if df.iloc[i + self.window_size + 1, 0] > df.iloc[i + self.window_size, 0] else 0
             X.append(window)
             y.append(label)
         X = np.stack(X)
         y = np.array(y)
-        # train + (val+test)
+
         X_train, X_temp, y_train, y_temp = train_test_split(
-            X, y, test_size=test_size+val_size, shuffle=False
+            X, y, test_size=test_size + val_size, shuffle=False
         )
-        # split val and test
         val_rel = val_size / (test_size + val_size)
         X_val, X_test, y_val, y_test = train_test_split(
             X_temp, y_temp, test_size=val_rel, shuffle=False
@@ -73,33 +76,26 @@ class DataAgent:
 
 
 # #########################
-# 2. TRF.2: TransformerAgent
+# 2. TRF.2: TransformerModel
 # #########################
-class TransformerAgent(nn.Module):
+class TransformerModel(nn.Module):
     """
     Transformer encoder + classifier for windowed data.
     """
     def __init__(self, feature_dim, d_model=64, nhead=4, num_layers=2):
         super().__init__()
-        # project input to model dimension
         self.input_proj = nn.Linear(feature_dim, d_model)
-        # transformer encoder layers
         layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead)
         self.encoder = nn.TransformerEncoder(layer, num_layers=num_layers)
-        # classification head
         self.classifier = nn.Linear(d_model, 2)
 
     def forward(self, x):
         # x: [batch, window, feature]
-        # project and reorder for transformer: [window, batch, d_model]
-        x = self.input_proj(x)  # [batch, window, d_model]
-        x = x.permute(1, 0, 2)
-        # encode
-        out = self.encoder(x)   # [window, batch, d_model]
-        # mean-pool over time
-        pooled = out.mean(dim=0)  # [batch, d_model]
-        # classify
-        logits = self.classifier(pooled)
+        x = self.input_proj(x)            # [batch, window, d_model]
+        x = x.permute(1, 0, 2)            # [window, batch, d_model]
+        out = self.encoder(x)             # [window, batch, d_model]
+        pooled = out.mean(dim=0)          # [batch, d_model]
+        logits = self.classifier(pooled)  # [batch, 2]
         return logits
 
     def train_model(self, train_loader, val_loader=None,
@@ -107,24 +103,28 @@ class TransformerAgent(nn.Module):
         """Training loop with optional early stopping and checkpoint."""
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.to(device)
-        opt = torch.optim.Adam(self.parameters(), lr=lr)
+        optimizer = torch.optim.Adam(self.parameters(), lr=lr)
         loss_fn = nn.CrossEntropyLoss()
         best_val = float('inf')
         wait = 0
-        for epoch in range(1, epochs+1):
-            self.train()
-            total = 0
+
+        for epoch in range(1, epochs + 1):
+            # set module to training mode
+            super().train()
+            total_loss = 0
             for xb, yb in train_loader:
                 xb, yb = xb.to(device), yb.to(device)
-                opt.zero_grad()
+                optimizer.zero_grad()
                 logits = self(xb)
                 loss = loss_fn(logits, yb)
                 loss.backward()
-                opt.step()
-                total += loss.item()
-            print(f"Epoch {epoch}, train loss: {total/len(train_loader):.4f}")
+                optimizer.step()
+                total_loss += loss.item()
+            print(f"Epoch {epoch}, train loss: {total_loss/len(train_loader):.4f}")
+
             if val_loader:
-                self.eval()
+                # set module to eval mode
+                super().eval()
                 val_loss = 0
                 with torch.no_grad():
                     for xb, yb in val_loader:
@@ -132,6 +132,7 @@ class TransformerAgent(nn.Module):
                         val_loss += loss_fn(self(xb), yb).item()
                 val_loss /= len(val_loader)
                 print(f"Epoch {epoch}, val loss: {val_loss:.4f}")
+
                 if val_loss < best_val:
                     best_val = val_loss
                     wait = 0
@@ -141,87 +142,165 @@ class TransformerAgent(nn.Module):
                     if wait >= patience:
                         print("Early stopping.")
                         break
+
         # load best model
         self.load_state_dict(torch.load(ckpt_path))
 
 
 # #########################
-# 3. TRF.3: EmbeddingAgent
+# 3. TRF.3: EmbeddingsExtractor
 # #########################
-class EmbeddingAgent:
+class EmbeddingsExtractor:
     """
-    Extracts embeddings from a trained TransformerAgent.
+    Extracts embeddings from a trained TransformerModel.
     """
     def __init__(self, model):
         self.model = model.eval()
 
-    def extract(self, loader, output_csv='embeddings.csv'):
-        """Generate embeddings and save with labels."""
-        import csv
-        device = next(self.model.parameters()).device
+    def extract_embeddings(self, loader, output_csv='embeddings.csv'):
+        """Generate embeddings (logits) and save with labels."""
         rows = []
+        device = next(self.model.parameters()).device
         with torch.no_grad():
             for xb, yb in loader:
                 xb = xb.to(device)
-                # get logits or embeddings before classifier
-                # here using classifier logits as embedding
                 emb = self.model(xb).cpu().numpy()
                 for vec, label in zip(emb, yb.numpy()):
                     rows.append(list(vec) + [int(label)])
-        # write CSV
-        cols = [f'emb_{i}' for i in range(len(rows[0])-1)] + ['label']
-        with open(output_csv, 'w', newline='') as f:
-            writer = csv.writer(f)
-            writer.writerow(cols)
-            writer.writerows(rows)
+        cols = [f'emb_{i}' for i in range(len(rows[0]) - 1)] + ['label']
+        pd.DataFrame(rows, columns=cols).to_csv(output_csv, index=False)
         print(f"Embeddings saved to {output_csv}")
 
-    def validate(self, csv_path, emb_dim):
+    def validate_embeddings(self, csv_path, emb_dim):
         """Check CSV has emb_dim cols + label."""
         df = pd.read_csv(csv_path)
-        assert df.shape[1] == emb_dim+1, f"Expected {emb_dim+1} cols, got {df.shape[1]}"
-        assert set(df['label'].unique()).issubset({0,1}), "Labels must be 0 or 1"
+        assert df.shape[1] == emb_dim + 1, f"Expected {emb_dim+1} cols, got {df.shape[1]}"
+        assert set(df['label'].unique()).issubset({0, 1}), "Labels must be 0 or 1"
         print("Embedding file validated.")
 
 
 # #########################
-# Main execution for TRF.1 - TRF.3
+# 4. TRF.4: XGBoostTrainer
+# #########################
+class XGBoostTrainer:
+    """
+    Loads embeddings, grid-searches hyperparameters, trains and saves XGBoost model.
+    """
+    def __init__(self, emb_csv='embeddings.csv'):
+        self.emb_csv = emb_csv
+
+    def train(self, output_model='xgb_model.joblib'):
+        df = pd.read_csv(self.emb_csv)
+        X = df.drop('label', axis=1).values
+        y = df['label'].values
+        X_train, X_val, y_train, y_val = train_test_split(
+            X, y, test_size=0.2, shuffle=False
+        )
+
+        param_grid = {
+            'n_estimators': [50, 100, 200],
+            'max_depth': [3, 5, 7],
+            'learning_rate': [0.01, 0.1, 0.2]
+        }
+        clf = xgb.XGBClassifier(use_label_encoder=False, eval_metric='logloss')
+        grid = GridSearchCV(clf, param_grid, cv=3, scoring='accuracy', verbose=1)
+        grid.fit(X_train, y_train)
+
+        best_model = grid.best_estimator_
+        joblib.dump(best_model, output_model)
+        print(f"Saved XGBoost model to {output_model}")
+        print(f"Best hyperparameters: {grid.best_params_}")
+        return best_model
+
+
+# #########################
+# 5. TRF.5: InferencePipeline
+# #########################
+class InferencePipeline:
+    """
+    Loads Transformer and XGBoost models, computes scores for a new window, emits JSON.
+    """
+    def __init__(self, transformer_path='transformer.pt', xgb_path='xgb_model.joblib',
+                 window_size=20):
+        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.transformer = None
+        self.transformer_path = transformer_path
+        self.xgb = joblib.load(xgb_path)
+        self.window_size = window_size
+        self.scaler = StandardScaler()
+
+    def load_transformer(self, feature_dim):
+        model = TransformerModel(feature_dim)
+        model.load_state_dict(torch.load(self.transformer_path, map_location=self.device))
+        self.transformer = model.to(self.device).eval()
+
+    def predict(self, ticker, start_date, end_date):
+        handler = DataHandler(ticker, start_date, end_date, self.window_size)
+        df = handler.fetch_ohlcv()
+        df = handler.impute_and_align(df)
+        df_norm = handler.normalize(df)
+
+        window = df_norm.values[-self.window_size:]
+        feature_dim = window.shape[1]
+        if self.transformer is None:
+            self.load_transformer(feature_dim)
+
+        xb = torch.tensor(window, dtype=torch.float32).unsqueeze(0).to(self.device)
+        with torch.no_grad():
+            logits = self.transformer(xb).cpu().numpy()
+            probs = F.softmax(torch.tensor(logits), dim=1).numpy()[0]
+
+        transformer_score = float(probs[1])
+        emb = logits
+        xgb_prob = float(self.xgb.predict_proba(emb)[0][1])
+
+        result = {
+            'date': end_date,
+            'transformer_score': transformer_score,
+            'xgb_prob': xgb_prob
+        }
+        print(json.dumps(result))
+        return result
+
+
+# #########################
+# Main execution for TRF.1 - TRF.5
 # #########################
 if __name__ == '__main__':
-    # Prompt user for input parameters
     ticker = input("Enter stock ticker (e.g. AAPL): ")
     start_date = input("Enter start date (YYYY-MM-DD): ")
-    end_date = input("Enter end date (YYYY-MM-DD): ")
+    end_date   = input("Enter end date (YYYY-MM-DD): ")
 
     # 1. Data ingestion & windowing
-    agent = DataAgent(ticker, start_date, end_date)
-    df = agent.fetch_ohlcv()
-    df = agent.impute_and_align(df)
-    df_norm = agent.normalize(df)
-    X_train, X_val, X_test, y_train, y_val, y_test = agent.create_windows(df_norm)
+    handler = DataHandler(ticker, start_date, end_date)
+    df = handler.fetch_ohlcv()
+    df = handler.impute_and_align(df)
+    df_norm = handler.normalize(df)
+    X_train, X_val, X_test, y_train, y_val, y_test = handler.create_windows(df_norm)
 
-    # Wrap data in DataLoader
-    train_loader = DataLoader(TensorDataset(
+    train_ld = DataLoader(TensorDataset(
         torch.tensor(X_train, dtype=torch.float32),
         torch.tensor(y_train, dtype=torch.long)
     ), batch_size=32, shuffle=True)
-    val_loader = DataLoader(TensorDataset(
+    val_ld = DataLoader(TensorDataset(
         torch.tensor(X_val, dtype=torch.float32),
         torch.tensor(y_val, dtype=torch.long)
     ), batch_size=32)
-    test_loader = DataLoader(TensorDataset(
-        torch.tensor(X_test, dtype=torch.float32),
-        torch.tensor(y_test, dtype=torch.long)
-    ), batch_size=32)
 
-    # 2. Transformer model training
+    # 2. Transformer training
     feature_dim = X_train.shape[2]
-    transformer = TransformerAgent(feature_dim)
-    transformer.train_model(train_loader, val_loader)
+    transformer = TransformerModel(feature_dim)
+    transformer.train_model(train_ld, val_ld)
 
-    # 3. Embedding extraction
-    embedder = EmbeddingAgent(transformer)
-    embedder.extract(train_loader, output_csv='embeddings.csv')
-    embedder.validate('embeddings.csv', emb_dim=2)  # 2 logits used as embedding size
+    # 3. Embedding extraction & validation
+    extractor = EmbeddingsExtractor(transformer)
+    extractor.extract_embeddings(train_ld, output_csv='embeddings.csv')
+    extractor.validate_embeddings('embeddings.csv', emb_dim=2)
 
-    
+    # 4. XGBoost training
+    xgb_trainer = XGBoostTrainer('embeddings.csv')
+    xgb_trainer.train(output_model='xgb_model.joblib')
+
+    # 5. (Optional) Inference example
+    infer = InferencePipeline('transformer.pt', 'xgb_model.joblib', window_size=handler.window_size)
+    infer.predict(ticker, start_date, end_date)


### PR DESCRIPTION
[TRF.4: XGBoost Training](https://github.com/Rivier-Computer-Science/AI-Agent-Stock-Prediction/issues/735)

[TRF.5: Inference Pipeline](https://github.com/Rivier-Computer-Science/AI-Agent-Stock-Prediction/issues/740)

This PR implements the remaining TRF.4 and TRF.5 tasks to complete the full transformer-to-XGBoost workflow:

TRF.4: XGBoost Training

Load embeddings & labels

Read the CSV of transformer logits plus labels into a pandas DataFrame.

Train/validation split

Split embeddings into training and validation sets (80/20, no shuffle).

Hyperparameter grid search

Use GridSearchCV to tune n_estimators, max_depth, and learning_rate for an XGBClassifier.

Train & serialize best model

Fit the best estimator on the training set and save it via joblib.dump.

TRF.5: Inference Pipeline

Model loading

Load the saved transformer checkpoint and XGBoost model in a unified InferencePipeline class.

Score computation

Given a new price window, compute the transformer’s probability score (transformer_score) and the XGBoost probability (xgb_prob).

JSON output

Emit a JSON object containing the query date, transformer score, and XGBoost probability for downstream consumption.